### PR TITLE
Add rage-rb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY Gemfile* /app/
 RUN bundle install
 COPY . /app
 EXPOSE 3000
-CMD bundle exec rails s -b 0.0.0.0
+CMD bundle exec rage s -b 0.0.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem "rails", "~> 7.0.6"
 
 gem "rage-rb"
+gem "http"
 
 # Use pg as the database for Active Record
 gem "pg"

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.6"
 
+gem "rage-rb"
+
 # Use pg as the database for Active Record
 gem "pg"
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,9 +21,6 @@ gem "puma", "~> 5.0"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 
-# Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-gem "rack-cors"
-
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
@@ -73,15 +75,31 @@ GEM
     debug (1.9.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    domain_name (0.6.20240107)
     erubi (1.12.0)
+    ffi (1.16.3)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     globalid (1.2.1)
       activesupport (>= 6.1)
+    http (5.1.1)
+      addressable (~> 2.8)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      llhttp-ffi (~> 0.4.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.7.1)
     irb (1.11.0)
       rdoc
       reline (>= 0.3.8)
+    llhttp-ffi (0.4.0)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -111,6 +129,7 @@ GEM
     pg (1.5.4)
     psych (5.1.2)
       stringio
+    public_suffix (5.0.4)
     puma (5.6.7)
       nio4r (~> 2.0)
     racc (1.7.3)
@@ -173,6 +192,7 @@ PLATFORMS
 
 DEPENDENCIES
   debug
+  http
   pg
   puma (~> 5.0)
   rage-rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,8 +115,6 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8)
-    rack-cors (2.0.1)
-      rack (>= 2.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
     rage-iodine (3.1.0)
@@ -177,7 +175,6 @@ DEPENDENCIES
   debug
   pg
   puma (~> 5.0)
-  rack-cors
   rage-rb
   rails (~> 7.0.6)
   tzinfo-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,13 @@ GEM
       rack (>= 2.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
+    rage-iodine (3.1.0)
+    rage-rb (1.5.0)
+      rack (~> 2.0)
+      rack-test (~> 2.1)
+      rage-iodine (~> 3.0)
+      thor (~> 1.0)
+      zeitwerk (~> 2.6)
     rails (7.0.8)
       actioncable (= 7.0.8)
       actionmailbox (= 7.0.8)
@@ -171,6 +178,7 @@ DEPENDENCIES
   pg
   puma (~> 5.0)
   rack-cors
+  rage-rb
   rails (~> 7.0.6)
   tzinfo-data
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,2 @@
-class ApplicationController < ActionController::API
+class ApplicationController < RageController::API
 end

--- a/app/interactors/create_booking.rb
+++ b/app/interactors/create_booking.rb
@@ -1,7 +1,19 @@
 class CreateBooking
   def call(start_time:, end_time:)
     Booking.create!(start_time: start_time, end_time: end_time)
+    Fiber.schedule { send_confirmation_email }
   rescue ActiveRecord::StatementInvalid
     :conflict
+  end
+
+  private
+
+  def send_confirmation_email
+    Rage.logger.tagged("ConfirmationEmail") do
+      HTTP.post("https://httpbin.org/delay/2")
+      Rage.logger.info "ok"
+    rescue => e
+      Rage.logger.error e
+    end
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -2,5 +2,4 @@
 
 require_relative "config/environment"
 
-run Rails.application
-Rails.application.load_server
+run Rage.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,3 +49,14 @@ module SlotBooking
 end
 
 require "rage/rails"
+
+Rails.configuration.after_initialize do
+  Rage.configure do
+    config.server.workers_count = 1
+
+    config.middleware.use ActionDispatch::HostAuthorization
+    if Rails.env.development?
+      config.middleware.use ActiveRecord::Migration::CheckPending
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,3 +47,5 @@ module SlotBooking
     end
   end
 end
+
+require "rage/rails"

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,16 +35,6 @@ module SlotBooking
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
-
-    config.middleware.insert_before 0, Rack::Cors do
-      allow do
-        origins "localhost:5173", "https://clumsy-squirrel-4315.pages.dev"
-
-        resource "*",
-          headers: :any,
-          methods: [:get, :post, :put, :patch, :delete, :options, :head]
-      end
-    end
   end
 end
 
@@ -53,6 +43,10 @@ require "rage/rails"
 Rails.configuration.after_initialize do
   Rage.configure do
     config.server.workers_count = 1
+
+    config.middleware.use Rage::Cors do
+      allow "localhost:5173", "https://clumsy-squirrel-4315.pages.dev"
+    end
 
     config.middleware.use ActionDispatch::HostAuthorization
     if Rails.env.development?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
-Rails.application.routes.draw do
+Rage.routes.draw do
   resources :bookings, only: %i(index create)
 end


### PR DESCRIPTION
The  PR migrates the application from using Rails to the Rage framework, and introduces asynchronous email confirmation for bookings.

* Switched the application from Rails to Rage by updating controller inheritance (`ApplicationController` now inherits from `RageController::API`), changing route and application initialization to use Rage, and updating the `Dockerfile` and `config.ru` to start the Rage server instead of Rails.
* Updated the application configuration to use Rage middleware and initialization hooks, including CORS and host authorization, replacing the previous Rack CORS setup.
* Modified the `CreateBooking` interactor to send a confirmation email asynchronously using `Fiber.schedule` and log the result or any errors.